### PR TITLE
ViewerCanvas.startModule module as return Value

### DIFF
--- a/src/pdf-viewer-canvas/PdfViewerCanvas.ts
+++ b/src/pdf-viewer-canvas/PdfViewerCanvas.ts
@@ -481,7 +481,8 @@ export class PdfViewerCanvas {
   public startModule(moduleName: string, args?: any) {
     const module = this.modules.find( m => { return m.name == moduleName})
     if (module) {
-      module.activate(args)
+      module.activate(args);
+      return module;
     }
   }
 


### PR DESCRIPTION
Gibt das aktivierte Module zurück, wodurch ein programmatisches ansteuern der Modul-Schnittstelle möglich ist.

Usage:

let module = viewer.startModule('MyModule', args);
module.doSomething()